### PR TITLE
add wait-for-it behaviour to mongo startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mongo:3.0.12
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /usr/local/bin/
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/a454892f3c2ebbc22bd15e446415b8fcb7c1cfa4/wait-for-it.sh /usr/local/bin/
 RUN chmod a+rx /usr/local/bin/wait-for-it.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["--replSet=development"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mongo:3.0.12
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /usr/local/bin/
+RUN chmod a+rx /usr/local/bin/wait-for-it.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["--replSet=development"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-
+E_UNAVAILABLE=69
 set -e
 
 if [ -n "$LOCAL_DEVICE" ]; then
@@ -13,7 +13,17 @@ PID=$!
 
 trap 'kill -INT $PID' EXIT
 
-sleep 10
-mongo --eval "rs.initiate()"
+# COULDDO: Read the port out of the environment?
+# COULDDO: Read timeout limit from the environment?
+/usr/local/bin/wait-for-it.sh -t 60 localhost:27017
 
-wait
+if [ $? -eq 0 ]
+then
+  echo Initializing replica set...
+  mongo --eval "rs.initiate()"
+  wait
+else
+  echo "Timed out waiting for mongo to start."
+  kill -INT $PID
+  exit $E_UNAVAILABLE
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ trap 'kill -INT $PID' EXIT
 
 # COULDDO: Read the port out of the environment?
 # COULDDO: Read timeout limit from the environment?
-/usr/local/bin/wait-for-it.sh -t 60 localhost:27017
+/usr/local/bin/wait-for-it.sh --timeout=60 localhost:27017
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
Support waiting longer by not necessarily waiting the entire time.