### PR TITLE
Configurable timeout

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,11 +17,13 @@ fi
 chown -R mongodb /data/configdb /data/db
 
 OPTIONS=
-if [[ -n "$REPL_SET_INIT" ]]; then
+if [[ -n "${REPL_SET_INIT+1}" ]]; then
   OPTIONS="--replSet=$REPL_SET_NAME"
   if [[ "$REPL_SET_INIT" == "join_arbiter" ]]; then
     OPTIONS="--nojournal --smallfiles ${OPTIONS}"
-  fi
+	fi
+else
+  REPL_SET_INIT="none"
 fi
 
 gosu mongodb mongod $OPTIONS $@ &

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,10 +18,14 @@ chown -R mongodb /data/configdb /data/db
 
 OPTIONS=
 if [[ -n "${REPL_SET_INIT+1}" ]]; then
-  OPTIONS="--replSet=$REPL_SET_NAME"
-  if [[ "$REPL_SET_INIT" == "join_arbiter" ]]; then
-    OPTIONS="--nojournal --smallfiles ${OPTIONS}"
-	fi
+  if [[ "${REPL_SET_INIT}" == "queryable_backup" ]]; then
+    OPTIONS="--queryableBackupMode"
+  else
+    OPTIONS="--replSet=$REPL_SET_NAME"
+    if [[ "${REPL_SET_INIT}" == "join_arbiter" ]]; then
+      OPTIONS="--nojournal --smallfiles ${OPTIONS}"
+		fi
+  fi
 else
   REPL_SET_INIT="none"
 fi
@@ -69,7 +73,7 @@ case "$REPL_SET_INIT" in
     ;;
 
   reconfig)
-    echo Reconfiguring replica set...
+    echo "Reconfiguring replica set..."
     # Try to read the 'uptime' key of the 0th member of the rs status command, and check if it is above 0
     until [[ $(mongo --quiet --eval 'JSON.stringify(rs.status())' | jq '.members[0].uptime//-1') -gt 0 ]]
     do

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ PID=$!
 trap 'kill -INT $PID' EXIT
 
 # COULDDO: Read the port out of the environment?
-if !  /usr/local/bin/wait-for-it.sh --timeout=$STARTUP_TIMEOUT localhost:27017; then
+if !  /usr/local/bin/wait-for-it.sh --timeout=${STARTUP_TIMEOUT} localhost:27017; then
   echo "Timed out waiting for mongo to start."
   exit $E_UNAVAILABLE
 fi
@@ -56,13 +56,14 @@ case "$REPL_SET_INIT" in
     done
 
     for i in "${REPL_SET_MEMBERS[@]}"; do
-      if /usr/local/bin/wait-for-it.sh --timeout=60 ${i}:27017; then mongo --eval "rs.add(\"$i\")"
+      if /usr/local/bin/wait-for-it.sh --timeout=${STARTUP_TIMEOUT} ${i}:27017; then
+        mongo --eval "rs.add(\"$i\")"
       else
         echo "Skipping replica set member ${i} due to timeout!"
       fi
     done
     if [[ -n ${REPL_SET_ARBITER:-} ]]; then
-      if /usr/local/bin/wait-for-it.sh --timeout=60 ${REPL_SET_ARBITER}:27017; then
+      if /usr/local/bin/wait-for-it.sh --timeout=${STARTUP_TIMEOUT} ${REPL_SET_ARBITER}:27017; then
         mongo --eval "rs.addArb(\"${REPL_SET_ARBITER}\")"
       else
         echo "Skipping replica set arbiter ${i} due to timeout!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,11 +7,11 @@ STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-60}"
 if [[ -n ${LOCAL_DEVICE:-} ]]; then
   mount ${LOCAL_DEVICE_FS:+-t $LOCAL_DEVICE_FS} ${LOCAL_DEVICE_FS_OPTS:+-o $LOCAL_DEVICE_FS_OPTS} $LOCAL_DEVICE /data/db
 
-	# HACK: This is a not a great idea.
-	# However, we can assert that our own snapshots were properly made, and cross
-	# our fingers and just hope that the server using this option knows what it
-	# is doing and doesn't spawn two mongos at once.
-	rm -f /data/db/mongod.lock
+  # HACK: This is a not a great idea.
+  # However, we can assert that our own snapshots were properly made, and cross
+  # our fingers and just hope that the server using this option knows what it
+  # is doing and doesn't spawn two mongos at once.
+  rm -f /data/db/mongod.lock
 fi
 
 chown -R mongodb /data/configdb /data/db
@@ -24,7 +24,7 @@ if [[ -n "${REPL_SET_INIT+1}" ]]; then
     OPTIONS="--replSet=$REPL_SET_NAME"
     if [[ "${REPL_SET_INIT}" == "join_arbiter" ]]; then
       OPTIONS="--nojournal --smallfiles ${OPTIONS}"
-		fi
+    fi
   fi
 else
   REPL_SET_INIT="none"
@@ -36,7 +36,6 @@ PID=$!
 trap 'kill -INT $PID' EXIT
 
 # COULDDO: Read the port out of the environment?
-# COULDDO: Read timeout limit from the environment?
 if !  /usr/local/bin/wait-for-it.sh --timeout=$STARTUP_TIMEOUT localhost:27017; then
   echo "Timed out waiting for mongo to start."
   exit $E_UNAVAILABLE
@@ -57,8 +56,7 @@ case "$REPL_SET_INIT" in
     done
 
     for i in "${REPL_SET_MEMBERS[@]}"; do
-      if /usr/local/bin/wait-for-it.sh --timeout=60 ${i}:27017; then
-        mongo --eval "rs.add(\"$i\")"
+      if /usr/local/bin/wait-for-it.sh --timeout=60 ${i}:27017; then mongo --eval "rs.add(\"$i\")"
       else
         echo "Skipping replica set member ${i} due to timeout!"
       fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 set -euo pipefail
 E_UNAVAILABLE=69
+STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-60}"
 
 # Mount LOCAL_DEVICE to /data/db, setting filesystem type and mount options if provided
 if [[ -n ${LOCAL_DEVICE:-} ]]; then
@@ -30,7 +31,7 @@ trap 'kill -INT $PID' EXIT
 
 # COULDDO: Read the port out of the environment?
 # COULDDO: Read timeout limit from the environment?
-if !  /usr/local/bin/wait-for-it.sh --timeout=60 localhost:27017; then
+if !  /usr/local/bin/wait-for-it.sh --timeout=$STARTUP_TIMEOUT localhost:27017; then
   echo "Timed out waiting for mongo to start."
   exit $E_UNAVAILABLE
 fi


### PR DESCRIPTION
support waiting longer than 60 seconds.

This is necessary for wiredTiger in prod reporting because the startup for it is quite slow.